### PR TITLE
Change routing_profiles.json and default profile

### DIFF
--- a/flask-app/router_proxy.py
+++ b/flask-app/router_proxy.py
@@ -18,7 +18,7 @@ ROUTING_PROFILES_FILE = "./static/routing_profiles.json"
 
 # load a list with names of valid routing profiles
 with open(ROUTING_PROFILES_FILE, "r", encoding="utf-8") as file:
-    VALID_ROUTING_PROFILES = json.load(file)
+    VALID_ROUTING_PROFILES = json.load(file).keys()
 
 
 class BadRequestArgumentException(Exception):
@@ -156,7 +156,7 @@ class RouteProfile(Parameter):
     @classmethod
     def parse(cls, s: str):
         if not s:
-            s = "car-fast"
+            s = "car-fasteco"
 
         if s not in VALID_ROUTING_PROFILES:
             raise ValueError("Invalid route profile name")

--- a/flask-app/static/routing_profiles.json
+++ b/flask-app/static/routing_profiles.json
@@ -1,29 +1,6 @@
-[
-    "car-eco",
-    "car-eco-nomotorway",
-    "car-eco-nounpaved",
-    "car-eco-tollfree",
-    "car-fast",
-    "car-fasteco",
-    "car-fasteco-nominorroads",
-    "car-fasteco-nomotorway",
-    "car-fasteco-nounpaved",
-    "car-fasteco-secondaryroads",
-    "car-fasteco-tertiaryroads",
-    "car-fasteco-tollfree",
-    "car-fasteco-tollfree-nominorroads",
-    "car-fasteco-tollfree-secondaryroads",
-    "car-fasteco-tollfree-tertiaryroads",
-    "car-fast-nominorroads",
-    "car-fast-nomotorway",
-    "car-fast-nounpaved",
-    "car-fast-secondaryroads",
-    "car-fast-tertiaryroads",
-    "car-fast-tollfree",
-    "car-fast-tollfree-nominorroads",
-    "car-fast-tollfree-secondaryroads",
-    "car-fast-tollfree-tertiaryroads",
-    "car-short",
-    "car-tollfree",
-    "car-vario"
-]
+{
+    "car-eco": "Ekonomicznie",
+    "car-fast": "Szybko",
+    "car-fasteco": "Zbalansowanie",
+    "car-short": "Najkrócej"
+}


### PR DESCRIPTION
- now a dict, mapping brouter names to translated friendly names
- default profile is now car-fasteco

Implements backend part of #43 